### PR TITLE
LIQ-163: Fix issues with wrong date display on history screen

### DIFF
--- a/app/src/main/java/com/tsquaredapplications/liquid/ext/CalendarExt.kt
+++ b/app/src/main/java/com/tsquaredapplications/liquid/ext/CalendarExt.kt
@@ -31,12 +31,12 @@ fun getStartAndEndTimeForToday(): Pair<Long, Long> {
     }
 }
 
-fun getEndTimeForToday(): Long =
+fun getStartTimeForToday(): Long =
     Calendar.getInstance().apply {
-        set(Calendar.HOUR_OF_DAY, 23)
-        set(Calendar.MINUTE, 59)
-        set(Calendar.SECOND, 59)
-        set(Calendar.MILLISECOND, 999)
+        set(Calendar.HOUR_OF_DAY, 0)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 1)
+        set(Calendar.MILLISECOND, 1)
     }.timeInMillis
 
 fun getStartOfDayFor(timestamp: Long) =
@@ -59,13 +59,13 @@ fun getEndTimeOfDayFor(timestamp: Long) =
 
 fun Calendar.getDayDisplayName(context: Context): String {
     return when (get(Calendar.DAY_OF_WEEK)) {
-        1 -> context.getString(R.string.monday)
-        2 -> context.getString(R.string.tuesday)
-        3 -> context.getString(R.string.wednesday)
-        4 -> context.getString(R.string.thursday)
-        5 -> context.getString(R.string.friday)
-        6 -> context.getString(R.string.saturday)
-        7 -> context.getString(R.string.sunday)
+        1 -> context.getString(R.string.sunday)
+        2 -> context.getString(R.string.monday)
+        3 -> context.getString(R.string.tuesday)
+        4 -> context.getString(R.string.wednesday)
+        5 -> context.getString(R.string.thursday)
+        6 -> context.getString(R.string.friday)
+        7 -> context.getString(R.string.saturday)
         else -> ""
     }
 }

--- a/app/src/main/java/com/tsquaredapplications/liquid/history/main/HistoryViewModel.kt
+++ b/app/src/main/java/com/tsquaredapplications/liquid/history/main/HistoryViewModel.kt
@@ -8,7 +8,7 @@ import com.tsquaredapplications.liquid.common.database.entry.EntryRepository
 import com.tsquaredapplications.liquid.common.database.goal.Goal
 import com.tsquaredapplications.liquid.common.database.goal.GoalRepository
 import com.tsquaredapplications.liquid.common.database.users.UserInformation
-import com.tsquaredapplications.liquid.ext.getEndTimeForToday
+import com.tsquaredapplications.liquid.ext.getStartTimeForToday
 import com.tsquaredapplications.liquid.history.main.HistoryState.Initialized
 import com.tsquaredapplications.liquid.history.main.resources.HistoryResourceWrapper
 import kotlinx.coroutines.async
@@ -49,7 +49,7 @@ class HistoryViewModel
             mutableListOf<HistoryDayItem.Model>()
 
         val startTime = Calendar.getInstance()
-        startTime.timeInMillis = getEndTimeForToday()
+        startTime.timeInMillis = getStartTimeForToday()
 
         var currentGoal = goals.first()
         goals.removeAt(0)


### PR DESCRIPTION
Fixed issue with wrong day name being displayed on history screen

Cause:

Calendar treats Sunday as first day of week
Also noticed that I was setting the start time to the end of the current date when parsing through entries and sorting them by day. This meant that the first loop would look for entries after the end of the current day which it would never find since you can't log future entries.