### PR TITLE
LIQ-151: Change way that UserInformation is provided

### DIFF
--- a/app/src/main/java/com/tsquaredapplications/liquid/MainModule.kt
+++ b/app/src/main/java/com/tsquaredapplications/liquid/MainModule.kt
@@ -4,7 +4,6 @@ import com.tsquaredapplications.liquid.add.amount.resources.DrinkAmountResourceW
 import com.tsquaredapplications.liquid.add.amount.resources.DrinkAmountResourceWrapperImpl
 import com.tsquaredapplications.liquid.add.drink.resources.SelectDrinkResourceWrapper
 import com.tsquaredapplications.liquid.add.drink.resources.SelectDrinkResourceWrapperImpl
-import com.tsquaredapplications.liquid.common.database.users.UserInformation
 import com.tsquaredapplications.liquid.history.day.resources.DayHistoryResourceWrapper
 import com.tsquaredapplications.liquid.history.day.resources.DayHistoryResourceWrapperImpl
 import com.tsquaredapplications.liquid.history.edit.resources.UpdateEntryResourceWrapper
@@ -30,11 +29,6 @@ import dagger.Provides
 
 @Module(subcomponents = [MainComponent::class])
 class MainModule {
-
-    lateinit var userInformation: UserInformation
-
-    @Provides
-    fun provideUserInformation(): UserInformation = userInformation
 
     @Provides
     fun provideHomeResourceWrapper(impl: HomeResourceWrapperImpl): HomeResourceWrapper = impl

--- a/app/src/main/java/com/tsquaredapplications/liquid/common/database/users/UserManager.kt
+++ b/app/src/main/java/com/tsquaredapplications/liquid/common/database/users/UserManager.kt
@@ -2,8 +2,9 @@ package com.tsquaredapplications.liquid.common.database.users
 
 interface UserManager {
     fun setUser(userInformation: UserInformation)
-    fun getUser(): UserInformation?
+    fun getUser(): UserInformation
     fun shouldShowAlcoholWarning(): Boolean
     fun setDonNotShowAlcoholWarning()
     fun updateGoal(goal: Int)
+    fun isUserSet(): Boolean
 }

--- a/app/src/main/java/com/tsquaredapplications/liquid/common/database/users/UserManagerImpl.kt
+++ b/app/src/main/java/com/tsquaredapplications/liquid/common/database/users/UserManagerImpl.kt
@@ -51,20 +51,16 @@ class UserManagerImpl
         }
     }
 
-    override fun getUser(): UserInformation? {
+    override fun getUser(): UserInformation {
         val sharedPrefs = context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
         val weight = sharedPrefs.getInt(WEIGHT, -1)
-        if (weight == -1) return null
 
         val dailyGoal = sharedPrefs.getInt(DAILY_GOAL, -1)
-        if (dailyGoal == -1) return null
 
         val unitPreferenceInt = sharedPrefs.getInt(UNIT_PREFERENCE, -1)
-        if (unitPreferenceInt == -1) return null
         val unitPreference = if (unitPreferenceInt == 0) LiquidUnit.OZ else LiquidUnit.ML
 
         val notificationsInt = sharedPrefs.getInt(NOTIFICATIONS_ENABLED, -1)
-        if (notificationsInt == -1) return null
         val notificationsEnabled = notificationsInt == 0
 
         val notificationStartTime = NotificationTime(
@@ -119,5 +115,10 @@ class UserManagerImpl
                 )
             )
         }
+    }
+
+    override fun isUserSet(): Boolean {
+        val sharedPrefs = context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
+        return sharedPrefs.getInt(WEIGHT, -1) != -1
     }
 }

--- a/app/src/main/java/com/tsquaredapplications/liquid/di/AppModule.kt
+++ b/app/src/main/java/com/tsquaredapplications/liquid/di/AppModule.kt
@@ -88,7 +88,6 @@ class AppModule(private val application: Application) {
     ): UserManager = impl
 
     @Provides
-    @Singleton
     fun provideUserInformation(userManager: UserManager): UserInformation = userManager.getUser()
 
     @Provides

--- a/app/src/main/java/com/tsquaredapplications/liquid/di/AppModule.kt
+++ b/app/src/main/java/com/tsquaredapplications/liquid/di/AppModule.kt
@@ -19,6 +19,7 @@ import com.tsquaredapplications.liquid.common.database.presets.RoomPresetReposit
 import com.tsquaredapplications.liquid.common.database.types.DrinkTypeDao
 import com.tsquaredapplications.liquid.common.database.types.RoomTypeRepository
 import com.tsquaredapplications.liquid.common.database.types.TypeRepository
+import com.tsquaredapplications.liquid.common.database.users.UserInformation
 import com.tsquaredapplications.liquid.common.database.users.UserManager
 import com.tsquaredapplications.liquid.common.database.users.UserManagerImpl
 import com.tsquaredapplications.liquid.common.notifications.NotificationManager
@@ -85,6 +86,10 @@ class AppModule(private val application: Application) {
     fun provideUserDatabaseManager(
         impl: UserManagerImpl
     ): UserManager = impl
+
+    @Provides
+    @Singleton
+    fun provideUserInformation(userManager: UserManager): UserInformation = userManager.getUser()
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/tsquaredapplications/liquid/setup/SetupActivity.kt
+++ b/app/src/main/java/com/tsquaredapplications/liquid/setup/SetupActivity.kt
@@ -6,12 +6,16 @@ import androidx.navigation.findNavController
 import com.tsquaredapplications.liquid.LiquidApplication
 import com.tsquaredapplications.liquid.R
 import com.tsquaredapplications.liquid.common.database.users.UserInformation
+import com.tsquaredapplications.liquid.common.database.users.UserManager
 import com.tsquaredapplications.liquid.databinding.ActivitySetupBinding
+import javax.inject.Inject
 
 class SetupActivity : AppCompatActivity() {
 
     lateinit var setupComponent: SetupComponent
     private lateinit var binding: ActivitySetupBinding
+
+    @Inject lateinit var userManager: UserManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         setupComponent = (applicationContext as LiquidApplication)
@@ -27,6 +31,6 @@ class SetupActivity : AppCompatActivity() {
         findNavController(R.id.hostFragment).navigateUp()
 
     fun setUserInformation(userInformation: UserInformation) {
-        (applicationContext as LiquidApplication).mainModule.userInformation = userInformation
+        userManager.setUser(userInformation)
     }
 }

--- a/app/src/main/java/com/tsquaredapplications/liquid/startup/SplashScreenFragment.kt
+++ b/app/src/main/java/com/tsquaredapplications/liquid/startup/SplashScreenFragment.kt
@@ -16,7 +16,7 @@ import javax.inject.Inject
 
 class SplashScreenFragment : BaseFragment<FragmentSplashScreenBinding>() {
     @Inject
-    lateinit var userDbManager: UserManager
+    lateinit var userManager: UserManager
 
     override fun setBinding(
         inflater: LayoutInflater,
@@ -39,14 +39,13 @@ class SplashScreenFragment : BaseFragment<FragmentSplashScreenBinding>() {
             }
             addListener(object : AnimatorListenerAdapter() {
                 override fun onAnimationEnd(animation: Animator?) {
-                    when (val userInformation = userDbManager.getUser()) {
-                        null -> {
-                            navigate(toLoginActivity())
+                    when (userManager.isUserSet()) {
+                        true -> {
+                            navigate(toMainActivity())
                             activity?.finish()
                         }
-                        else -> {
-                            (activity as StartupActivity).saveUserInformation(userInformation)
-                            navigate(toMainActivity())
+                        false -> {
+                            navigate(toLoginActivity())
                             activity?.finish()
                         }
                     }

--- a/app/src/main/java/com/tsquaredapplications/liquid/startup/StartupActivity.kt
+++ b/app/src/main/java/com/tsquaredapplications/liquid/startup/StartupActivity.kt
@@ -3,7 +3,6 @@ package com.tsquaredapplications.liquid.startup
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.tsquaredapplications.liquid.LiquidApplication
-import com.tsquaredapplications.liquid.common.database.users.UserInformation
 import com.tsquaredapplications.liquid.databinding.ActivityStartupBinding
 
 class StartupActivity : AppCompatActivity() {
@@ -19,9 +18,5 @@ class StartupActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityStartupBinding.inflate(layoutInflater)
         setContentView(binding.root)
-    }
-
-    fun saveUserInformation(userInformation: UserInformation) {
-        (applicationContext as LiquidApplication).mainModule.userInformation = userInformation
     }
 }


### PR DESCRIPTION
Notifications were failing due to the way that UserInformation was being provided. 

Previously the startup activity would determine if the user was set up and add that UserInformation object to the MainModule and it was provided to injection locations. 

This would case launching MainActivity to fail since StartupActivity was being bypassed and the user information in the main module was not being set. 

Now we are using the user manager to retrieve the user information object so that it can be retrieved from any location without depending on the value of the main module being set. 

Caveat is that user must be setup otherwise the user information retrieved would be default values. This should be avoidable since the only way as of now to launch directly to the MainActivity bypassing the StartupActivity is by notification which will only be fired after user is setup.